### PR TITLE
Improve team page 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ composer/
 ssl/ssl.key
 
 nouseprod.env
+dist

--- a/readers-frontend/astro.config.prod.ts
+++ b/readers-frontend/astro.config.prod.ts
@@ -32,7 +32,6 @@ export default defineConfig({
       "import.meta.env.PUBLIC_BASE_URL": JSON.stringify(
         process.env.PUBLIC_BASE_URL || "https://nouse.co.uk",
       ),
-      // Not loading from env file?
       "import.meta.env.PUBLIC_SITE_ASSETS_URL": JSON.stringify(
         process.env.PUBLIC_SITE_ASSETS_URL ||
           "https://bbcdn.nouse.co.uk/file/nouseSiteAssets",

--- a/readers-frontend/astro.config.ts
+++ b/readers-frontend/astro.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
       "import.meta.env.PUBLIC_BASE_URL": JSON.stringify(
         process.env.PUBLIC_BASE_URL || "http://localhost:3000",
       ),
-      // Not loading from env file?
       "import.meta.env.PUBLIC_SITE_ASSETS_URL": JSON.stringify(
         process.env.PUBLIC_SITE_ASSETS_URL ||
           "https://bbcdn.nouse.co.uk/file/nouseSiteAssets",

--- a/readers-frontend/src/pages/team.astro
+++ b/readers-frontend/src/pages/team.astro
@@ -4,14 +4,13 @@ import { type Position } from "@components/types";
 
 const apiBase = import.meta.env.PUBLIC_API_BASE_URL;
 
-async function getTeam() : Promise<Position[]> {
-  try{
+async function getTeam(): Promise<Position[]> {
+  try {
     const res = await fetch(`${apiBase}/api/frontend/team`);
     const positions: Position[] = await res.json();
     return positions;
-  }
-  catch(error){
-    return []
+  } catch (error) {
+    return [];
   }
 }
 //const res = await fetch(`${apiBase}/api/frontend/team`);
@@ -19,20 +18,19 @@ const positions: Position[] = await getTeam();
 ---
 
 <Layout title="Nouse" active="home" style={"nouse"}>
-  
-  <div class="px-[3%] pt-8 sm:px-[0.5%] 2xl:px-[13%] ">
+  <div class="px-[3%] pt-8 sm:px-[0.5%] 2xl:px-[13%]">
     <h1 class="mb-2 text-center text-2xl sm:text-4xl">Meet The Team</h1>
-    
+
     <figure class="mt-8 flex flex-col items-center">
-  <img
-    src={`${import.meta.env.PUBLIC_SITE_ASSETS_URL}/teamPhotos/202526Team.jpg`}
-    alt="Nouse team photo"
-    class="max-w-md h-auto rounded-lg"
-  />
-  <figcaption class="mt-2 text-sm text-gray-700">
-    Nouse Winter Formal, December 2025.
-  </figcaption>
-</figure>
+      <img
+        src={`${import.meta.env.PUBLIC_SITE_ASSETS_URL}/teamPhotos/202526Team.jpg`}
+        alt="Nouse team photo"
+        class="max-w-md h-auto rounded-lg"
+      />
+      <figcaption class="mt-2 text-sm text-gray-700">
+        Nouse Winter Formal, December 2025.
+      </figcaption>
+    </figure>
 
     <div id="senior-team" class="mb-4">
       <p class="mb-4 text-xl font-bold sm:text-2xl">Senior Team</p>

--- a/readers-frontend/src/pages/team.astro
+++ b/readers-frontend/src/pages/team.astro
@@ -4,20 +4,38 @@ import { type Position } from "@components/types";
 
 const apiBase = import.meta.env.PUBLIC_API_BASE_URL;
 
-const res = await fetch(`${apiBase}/api/frontend/team`);
-const positions: Position[] = await res.json();
+async function getTeam() : Promise<Position[]> {
+  try{
+    const res = await fetch(`${apiBase}/api/frontend/team`);
+    const positions: Position[] = await res.json();
+    return positions;
+  }
+  catch(error){
+    return []
+  }
+}
+//const res = await fetch(`${apiBase}/api/frontend/team`);
+const positions: Position[] = await getTeam();
 ---
 
 <Layout title="Nouse" active="home" style={"nouse"}>
+  
+  <div class="px-[3%] pt-8 sm:px-[0.5%] 2xl:px-[13%] ">
+    <h1 class="mb-2 text-center text-2xl sm:text-4xl">Meet The Team</h1>
+    
+    <figure class="mt-8 flex flex-col items-center">
   <img
-    class="mt-8 h-80 w-full object-cover"
     src={`${import.meta.env.PUBLIC_SITE_ASSETS_URL}/teamPhotos/202526Team.jpg`}
     alt="Nouse team photo"
+    class="max-w-md h-auto rounded-lg"
   />
-  <div class="px-[3%] pt-8 sm:px-[0.5%] 2xl:px-[13%]">
-    <h1 class="mb-4 text-2xl sm:text-4xl">Meet The Team</h1>
+  <figcaption class="mt-2 text-sm text-gray-700">
+    Nouse Winter Formal, December 2025.
+  </figcaption>
+</figure>
+
     <div id="senior-team" class="mb-4">
-      <p class="mb-2 text-xl font-bold sm:text-2xl">Senior Team</p>
+      <p class="mb-4 text-xl font-bold sm:text-2xl">Senior Team</p>
       <div
         class="grid flex-wrap text-sm md:grid-cols-2 xl:text-base 2xl:text-lg"
       >
@@ -46,7 +64,7 @@ const positions: Position[] = await res.json();
       </div>
     </div>
     <div id="nouse" class="mb-4">
-      <p class="mb-2 text-xl font-bold sm:text-2xl">Nouse</p>
+      <p class="mb-4 text-xl font-bold sm:text-2xl">Nouse</p>
       <div
         class="grid flex-wrap text-sm md:grid-cols-2 xl:text-base 2xl:text-lg"
       >
@@ -75,7 +93,7 @@ const positions: Position[] = await res.json();
       </div>
     </div>
     <div id="muse" class="mb-4">
-      <p class="mb-2 text-xl font-bold sm:text-2xl">MUSE</p>
+      <p class="mb-4 text-xl font-bold sm:text-2xl">MUSE</p>
       <div
         class="grid flex-wrap text-sm md:grid-cols-2 xl:text-base 2xl:text-lg"
       >


### PR DESCRIPTION
Moved "Meet the team" title to centre to be consistent with "about us" page.
Styled team photo to support title in centre of page.

Added minor spacing to team sections.
Added error handling to display no team members if can't fetch. 

<img width="1912" height="896" alt="image" src="https://github.com/user-attachments/assets/db47f613-1fb5-4a3d-9917-086ba5368049" />





