### PR TITLE
Authors Pagination Issue Hotfix

### DIFF
--- a/readers-frontend/src/components/AuthorArticles.astro
+++ b/readers-frontend/src/components/AuthorArticles.astro
@@ -32,7 +32,7 @@ const authorArticles: AuthorArticles = await res.json();
       client:only
       page={pageNumber === 0 ? pageNumber : pageNumber - 1}
       pages={authorArticles.pages}
-      pagesToDisplay={5}
+      pagesToDisplay={4}
       prefix={`author/${authorId}`}
       useQueryParams={true}
     />


### PR DESCRIPTION
This is to fix pagination edge case for the Authors page where it looks like if there is one article on the last page then the page is left out. Quick workaround to make all the pages show without looking further into the Paginator component. 

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/c86fc106-c79c-4dfc-9aeb-14faa486e512" />
